### PR TITLE
Apply one-hot to nominal predictions only

### DIFF
--- a/R/define_target.R
+++ b/R/define_target.R
@@ -72,7 +72,7 @@ prepare_data_for_modelling <- function(data, target){
         mydata <-
           mydata %>%
           recipes::recipe( ~ .) %>%
-          recipes::step_dummy(recipes::all_predictors(), -recipes::all_numeric(), -target$id_variable, -target$target_variable, one_hot = T) %>%
+          recipes::step_dummy(recipes::all_nominal_predictors(), -target$id_variable, -target$target_variable, one_hot = T) %>%
           recipes::prep() %>%
           recipes::bake(mydata) %>%
           mutate_if(is.logical, as.integer)


### PR DESCRIPTION
Datetime and other such columns were not excluded, which usually made an error be raised at some point.